### PR TITLE
fix docs: Scan Request PGN 202 src

### DIFF
--- a/PGN.md
+++ b/PGN.md
@@ -807,8 +807,8 @@ Port = 5122<br>
         </tr>
         <tr>
             <td align=center>Scan request</td>
-            <td align=center>7B</td>
-            <td align=center>123</td>
+            <td align=center>7F</td>
+            <td align=center>127</td>
             <td align=center>CA</td>
             <td align=center>202</td>
             <td align=center>3</td>


### PR DESCRIPTION
Fix the docs to show the correct src value of the scan request PGN 202 as it should be coming from AgIO 0x7F 127.

https://github.com/AgOpenGPS-Official/AgOpenGPS/blob/85e1dc02a3ee6e0e426d4a75220187040d1f1e55/SourceCode/AgIO/Source/Forms/FormUDP.cs#L136

This is correctly documented in the excel file
![image](https://github.com/user-attachments/assets/25339809-053e-4f37-881b-c657606b3ce3)
