### PR TITLE
Link to new documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Click on the green "Code" button above and select "Download Zip" to download the entire support folder.
 
-The [AgOpenGPS Hardware Wiki](https://github.com/AgOpenGPS-Official/Boards/wiki)
-
 In this repository are many files containing the firmware and pcb layouts to make the hardware for AgOpenGPS.
 
 The Arduino folder contains all the "older" firmware that worked with the Nano for steering, machine control, and the no longer used external IMU.
@@ -12,8 +10,8 @@ The Misc folder has various projects including Matthias switch syste, ESP32 proj
 
 The Teensy folder has the latest All in One firmware and PCB gerbers etc. 
 
---------------------------------------------------------------------------------------------------------------
+## Links
 
-Are you looking for [AgOpenGPS Repository](https://github.com/farmerbriantee/AgOpenGPS) ?
-
-For the [Latest AgOpenGPS Release](https://github.com/farmerbriantee/AgOpenGPS/releases) ?
+- [AgOpenGPS Repository](https://github.com/AgOpenGPS-Official/AgOpenGPS)
+  - [Latest AgOpenGPS Release](https://github.com/AgOpenGPS-Official/AgOpenGPS/releases)
+- [AgOpenGPS Documentation](https://docs.agopengps.com/)


### PR DESCRIPTION
Links to the new documentation site (https://docs.agopengps.com/) instead of the Wikis.