### PR TITLE
Simple Ethernet Setup for the AIO Board using DHCP

### DIFF
--- a/TeensyModules/AIO v4 Firmware/AIO_v4_Firmware/AIO_v4_Firmware.ino
+++ b/TeensyModules/AIO v4 Firmware/AIO_v4_Firmware/AIO_v4_Firmware.ino
@@ -100,8 +100,7 @@ char Eth_DHCP_packetBuffer[DHCP_MESSAGE_SIZE];      // buffer for dhcp packets
 EthernetUDP Eth_udpPAOGI;     //Out port 5544
 EthernetUDP Eth_udpNtrip;     //In port 2233
 EthernetUDP Eth_udpAutoSteer; //In & Out Port 8888
-EthernetUDP Eth_udpListenDHCP; //In Port 67
-EthernetUDP Eth_udpTransmitDHCP; //Out Port 68
+EthernetUDP Eth_udpDHCP; //In & Out Port 67
 
 IPAddress Eth_ipDestination;
 
@@ -283,20 +282,20 @@ void loop()
     }
 
     // Check for DHCP messages via UDP
-    unsigned int packetLengthDHCP = Eth_udpListenDHCP.parsePacket();
+    unsigned int packetLengthDHCP = Eth_udpDHCP.parsePacket();
 
     if (packetLengthDHCP > 0)
     {
         // read DHCP message
-        Eth_udpListenDHCP.read(Eth_DHCP_packetBuffer, packetLengthDHCP);
+        Eth_udpDHCP.read(Eth_DHCP_packetBuffer, packetLengthDHCP);
 
         // generate DHCP message
         packetLengthDHCP = DHCPreply((RIP_MSG*)Eth_DHCP_packetBuffer, packetLengthDHCP, Eth_myip, domainName);
 
         // send DHCP message
-        Eth_udpTransmitDHCP.beginPacket(Eth_ipDestination, DHCP_CLIENT_PORT);
-        Eth_udpTransmitDHCP.write(Eth_DHCP_packetBuffer, packetLengthDHCP);
-        Eth_udpTransmitDHCP.endPacket();
+        Eth_udpDHCP.beginPacket(Eth_ipDestination, DHCP_CLIENT_PORT);
+        Eth_udpDHCP.write(Eth_DHCP_packetBuffer, packetLengthDHCP);
+        Eth_udpDHCP.endPacket();
     }
 
     // Check for RTK via UDP

--- a/TeensyModules/AIO v4 Firmware/AIO_v4_Firmware/DHCP.cpp
+++ b/TeensyModules/AIO v4 Firmware/AIO_v4_Firmware/DHCP.cpp
@@ -1,0 +1,168 @@
+// Copyright (C) 2011 by Paul Kulchenko
+
+#include "DHCP.h"
+
+unsigned short htons(unsigned short x) { /** A 16-bit number in host byte order. */
+#if ( SYSTEM_ENDIAN == _ENDIAN_LITTLE_ )
+        return ((x)<<8) | (((x)>>8)&0xFF);
+#else
+        return x;
+#endif          
+}
+
+unsigned long computeChecksum(byte *buf, int length) {
+  unsigned long h = 0;
+  unsigned long highorder;
+
+  // based on CRC algorithm from http://www.cs.hmc.edu/~geoff/classes/hmc.cs070.200101/homework10/hashfuncs.html
+  for (int i = 0; i < length; i++) {
+    highorder = h & 0xf8000000;    // extract high-order 5 bits from h
+    h = h << 5;                    // shift h left by 5 bits
+    h = h ^ (highorder >> 27);     // move the highorder 5 bits to the low-order end
+    h = h ^ tolower(buf[i]);       // this is to allow "MyPC" and "mypc" to be the same
+  }
+  return h;
+}
+
+byte quads[4];
+byte * long2quad(unsigned long value) {
+  for (int k = 0; k < 4; k++) quads[3-k] = value >> (k * 8);
+  return quads;
+}
+
+Lease Leases[LEASESNUM];
+
+// leases are numbered 1..LEASENUM (to use 0 to signal no lease)
+void setLease(byte lease, unsigned long crc, long expires, byte status, unsigned long hostcrc) {
+  if (lease > 0 && lease <= LEASESNUM) {
+    Leases[lease-1].maccrc = crc;
+    Leases[lease-1].expires = expires; 
+    Leases[lease-1].status = status;
+    Leases[lease-1].hostcrc = hostcrc;
+  }
+}
+
+byte getLease(unsigned long crc) {
+  for (byte lease = 0; lease < LEASESNUM; lease++)
+    if (Leases[lease].maccrc == crc) return lease+1;
+  
+  // Clean up expired leases; need to do after we check for existing leases because of this iOS bug
+  // http://www.net.princeton.edu/apple-ios/ios41-allows-lease-to-expire-keeps-using-IP-address.html
+  // Don't need to check again AFTER the clean up as for DHCP REQUEST the client should already have the lease
+  // and for DHCP DISCOVER we will check once more to assign a new lease
+  long currTime = millis();
+  for (byte lease = 0; lease < LEASESNUM; lease++)
+    if (Leases[lease].expires < currTime) setLease(lease+1, 0, 0, DHCP_LEASE_AVAIL, 0);
+
+  return 0;
+}
+
+byte getLeaseByHost(unsigned long crc) {
+  for (byte lease = 0; lease < LEASESNUM; lease++)
+    if (Leases[lease].hostcrc == crc && Leases[lease].status == DHCP_LEASE_ACK) 
+      return lease+1;
+  return 0;
+}
+
+int getOption(int dhcpOption, byte *options, int optionSize, int *optionLength) {
+  for(int i=0; i<optionSize && (options[i] != dhcpEndOption); i += 2 + options[i+1]) {
+    if(options[i] == dhcpOption) {
+      if (optionLength) *optionLength = (int)options[i+1];
+      return i+2;
+    }
+  }
+  if (optionLength) *optionLength = 0;
+  return 0;
+}
+
+int populatePacket(byte *packet, int currLoc, byte marker, byte *what, int dataSize) {
+  packet[currLoc] = marker;
+  packet[currLoc+1] = dataSize;
+  memcpy(packet+currLoc+2,what,dataSize);
+  return dataSize + 2;
+}
+
+int DHCPreply(RIP_MSG *packet, int packetSize, byte *serverIP, char *domainName) {
+  if (packet->op != DHCP_BOOTREQUEST) return 0; // limited check that we're dealing with DHCP/BOOTP request
+
+  byte OPToffset = (byte*)packet->OPT-(byte*)packet;
+
+  packet->op = DHCP_BOOTREPLY;
+  packet->secs = 0; // some of the secs come malformed; don't want to send them back
+
+  unsigned long crc = computeChecksum(packet->chaddr, packet->hlen);
+
+  int dhcpMessageOffset = getOption(dhcpMessageType, packet->OPT, packetSize-OPToffset, NULL);
+  byte dhcpMessage = packet->OPT[dhcpMessageOffset];
+
+  byte lease = getLease(crc);
+  byte response = DHCP_NAK;
+  if (dhcpMessage == DHCP_DISCOVER) {
+    if (!lease) lease = getLease(0); // use existing lease or get a new one
+    if (lease) {
+      response = DHCP_OFFER;
+      setLease(lease, crc, millis() + 10000, DHCP_LEASE_OFFER, 0); // 10s
+    }
+  }  
+  else if (dhcpMessage == DHCP_REQUEST) {
+    if (lease) {
+      response = DHCP_ACK;
+
+      // find hostname option in the request and store to provide DNS info
+      int hostNameLength;
+      int hostNameOffset = getOption(dhcpHostName, packet->OPT, packetSize-OPToffset, &hostNameLength);
+      unsigned long nameCrc = hostNameOffset 
+        ? computeChecksum(packet->OPT + hostNameOffset, hostNameLength) 
+        : 0;
+      setLease(lease, crc, millis() + DHCP_LEASETIME * 1000, DHCP_LEASE_ACK, nameCrc); // DHCP_LEASETIME is in seconds
+    }
+  }
+
+  if (lease) { // Dynamic IP configuration
+    memcpy(packet->yiaddr, serverIP, 4);
+    packet->yiaddr[3] += lease; // lease starts with 1
+  }  
+      
+  int currLoc = 0; 
+  packet->OPT[currLoc++] = dhcpMessageType;
+  packet->OPT[currLoc++] = 1;
+  packet->OPT[currLoc++] = response;
+
+  int reqLength; 
+  int reqListOffset = getOption(dhcpParamRequest, packet->OPT, packetSize-OPToffset, &reqLength);
+  byte reqList[12]; if (reqLength > 12) reqLength = 12;
+  memcpy(reqList, packet->OPT + reqListOffset, reqLength);
+
+  // iPod with iOS 4 doesn't want to process DHCP OFFER if dhcpServerIdentifier does not follow dhcpMessageType
+  // Windows Vista and Ubuntu 11.04 don't seem to care
+  currLoc += populatePacket(packet->OPT, currLoc, dhcpServerIdentifier, serverIP, 4);
+
+  // DHCP lease timers: http://www.tcpipguide.com/free/t_DHCPLeaseLifeCycleOverviewAllocationReallocationRe.htm
+  // Renewal Timer (T1): This timer is set by default to 50% of the lease period.
+  // Rebinding Timer (T2): This timer is set by default to 87.5% of the length of the lease.
+  currLoc += populatePacket(packet->OPT, currLoc, dhcpIPaddrLeaseTime, long2quad(DHCP_LEASETIME), 4); 
+  currLoc += populatePacket(packet->OPT, currLoc, dhcpT1value, long2quad(DHCP_LEASETIME*0.5), 4); 
+  currLoc += populatePacket(packet->OPT, currLoc, dhcpT2value, long2quad(DHCP_LEASETIME*0.875), 4);
+
+  for(int i=0; i<reqLength; i++) {
+    switch(reqList[i]) {
+      case dhcpSubnetMask:
+        currLoc += populatePacket(packet->OPT, currLoc, reqList[i], long2quad(0xFFFFFF00UL), 4); // 255.255.255.0
+        break;
+      case dhcpLogServer:
+        currLoc += populatePacket(packet->OPT, currLoc, reqList[i], long2quad(0), 4);
+        break;
+      case dhcpDns:
+      case dhcpRoutersOnSubnet:
+        currLoc += populatePacket(packet->OPT, currLoc, reqList[i], serverIP, 4);
+        break;
+      case dhcpDomainName:
+        if (domainName && strlen(domainName))
+          currLoc += populatePacket(packet->OPT, currLoc, reqList[i], (byte*)domainName, strlen(domainName));
+        break;
+    }
+  }
+  packet->OPT[currLoc++] = dhcpEndOption;
+
+  return OPToffset+currLoc;
+}

--- a/TeensyModules/AIO v4 Firmware/AIO_v4_Firmware/DHCP.h
+++ b/TeensyModules/AIO v4 Firmware/AIO_v4_Firmware/DHCP.h
@@ -1,0 +1,138 @@
+// DHCP Lite header
+
+#ifndef	DHCP_LITE_H
+#define DHCP_LITE_H
+
+#include "Arduino.h"
+
+#define DHCP_MESSAGE_SIZE	576     /* a DHCP client must be prepared to receive a message of up to 576 octets */
+
+/* UDP port numbers for DHCP */
+#define	DHCP_SERVER_PORT	67	/* port for server to listen on */
+#define DHCP_CLIENT_PORT	68	/* port for client to use */
+
+/* DHCP message OP code */
+#define DHCP_BOOTREQUEST	1
+#define DHCP_BOOTREPLY		2
+
+/* DHCP message type */
+#define	DHCP_DISCOVER		1
+#define DHCP_OFFER		2
+#define	DHCP_REQUEST		3
+#define	DHCP_DECLINE		4
+#define	DHCP_ACK		5
+#define DHCP_NAK		6
+#define	DHCP_RELEASE		7
+#define DHCP_INFORM		8
+
+#define DHCP_LEASETIME ((long)60*60*24) // Lease Time: 1 day == { 00, 01, 51, 80 }
+
+/* DHCP lease status */
+#define DHCP_LEASE_AVAIL	0
+#define DHCP_LEASE_OFFER	1
+#define DHCP_LEASE_ACK		2
+
+struct Lease {
+	unsigned long maccrc;
+	long expires;
+	byte status;
+	unsigned long hostcrc;
+};
+
+#define LEASESNUM 12
+
+/**
+ * @brief	DHCP option and value (cf. RFC1533)
+ */
+enum {
+	dhcpPadOption			=	0,
+	dhcpSubnetMask			=	1,
+	dhcpTimerOffset			=	2,
+	dhcpRoutersOnSubnet		=	3,
+	dhcpTimeServer			=	4,
+	dhcpNameServer			=	5,
+	dhcpDns				=	6,
+	dhcpLogServer			=	7,
+	dhcpCookieServer		=	8,
+	dhcpLprServer			=	9,
+	dhcpImpressServer		=	10,
+	dhcpResourceLocationServer	=	11,
+	dhcpHostName			=	12,
+	dhcpBootFileSize		=	13,
+	dhcpMeritDumpFile		=	14,
+	dhcpDomainName			=	15,
+	dhcpSwapServer			=	16,
+	dhcpRootPath			=	17,
+	dhcpExtentionsPath		=	18,
+	dhcpIPforwarding		=	19,
+	dhcpNonLocalSourceRouting	=	20,
+	dhcpPolicyFilter		=	21,
+	dhcpMaxDgramReasmSize		=	22,
+	dhcpDefaultIPTTL		=	23,
+	dhcpPathMTUagingTimeout		=	24,
+	dhcpPathMTUplateauTable		=	25,
+	dhcpIfMTU			=	26,
+	dhcpAllSubnetsLocal		=	27,
+	dhcpBroadcastAddr		=	28,
+	dhcpPerformMaskDiscovery	=	29,
+	dhcpMaskSupplier		=	30,
+	dhcpPerformRouterDiscovery	=	31,
+	dhcpRouterSolicitationAddr	=	32,
+	dhcpStaticRoute			=	33,
+	dhcpTrailerEncapsulation	=	34,
+	dhcpArpCacheTimeout		=	35,
+	dhcpEthernetEncapsulation	=	36,
+	dhcpTcpDefaultTTL		=	37,
+	dhcpTcpKeepaliveInterval	=	38,
+	dhcpTcpKeepaliveGarbage		=	39,
+	dhcpNisDomainName		=	40,
+	dhcpNisServers			=	41,
+	dhcpNtpServers			=	42,
+	dhcpVendorSpecificInfo		=	43,
+	dhcpNetBIOSnameServer		=	44,
+	dhcpNetBIOSdgramDistServer	=	45,
+	dhcpNetBIOSnodeType		=	46,
+	dhcpNetBIOSscope		=	47,
+	dhcpXFontServer			=	48,
+	dhcpXDisplayManager		=	49,
+	dhcpRequestedIPaddr		=	50,
+	dhcpIPaddrLeaseTime		=	51,
+	dhcpOptionOverload		=	52,
+	dhcpMessageType			=	53,
+	dhcpServerIdentifier		=	54,
+	dhcpParamRequest		=	55,
+	dhcpMsg				=	56,
+	dhcpMaxMsgSize			=	57,
+	dhcpT1value			=	58,
+	dhcpT2value			=	59,
+	dhcpClassIdentifier		=	60,
+	dhcpClientIdentifier		=	61,
+	dhcpEndOption			=	255
+};
+
+/**
+ * @brief		for the DHCP message
+ */
+typedef struct RIP_MSG {
+	byte		op;
+	byte		htype;
+	byte		hlen;
+	byte		hops;
+	uint32_t	xid;
+	uint16_t	secs;
+#define DHCP_FLAG_BROADCAST (0x8000)
+        uint16_t	flags;
+	byte		ciaddr[4];  // Client IP
+	byte		yiaddr[4];  // Your IP
+	byte		siaddr[4];  // Server IP
+	byte		giaddr[4];  // Gateway IP
+	byte		chaddr[16]; // Client hardware address (zero padded)
+	byte		sname[64];
+	byte		file[128];
+#define DHCP_MAGIC (0x63825363)
+        byte    	magic[4]; 
+	byte		OPT[]; // 240 offset
+};
+
+int DHCPreply(RIP_MSG *packet, int packetSize, byte *serverIP, char *domainName);
+#endif

--- a/TeensyModules/AIO v4 Firmware/AIO_v4_Firmware/zEthernet.ino
+++ b/TeensyModules/AIO v4 Firmware/AIO_v4_Firmware/zEthernet.ino
@@ -67,17 +67,10 @@ void EthernetStart()
     Serial.println(AOGAutoSteerPort);
   }
 
-  // init UPD Port getting DHCP messages
-  if (Eth_udpListenDHCP.begin(DHCP_SERVER_PORT))
+  // init UPD Port for DHCP
+  if (Eth_udpDHCP.begin(DHCP_SERVER_PORT))
   {
     Serial.print("Ethernet DHCP UDP listening to port: ");
     Serial.println(DHCP_SERVER_PORT);
-  }
-
-  // init UPD Port sending DHCP messages
-  if (Eth_udpTransmitDHCP.begin(DHCP_CLIENT_PORT))
-  {
-    Serial.print("Ethernet DHCP UDP sending from port: ");
-    Serial.println(DHCP_CLIENT_PORT);
   }
 }

--- a/TeensyModules/AIO v4 Firmware/AIO_v4_Firmware/zEthernet.ino
+++ b/TeensyModules/AIO v4 Firmware/AIO_v4_Firmware/zEthernet.ino
@@ -66,4 +66,18 @@ void EthernetStart()
     Serial.print("Ethernet AutoSteer UDP listening to & send from port: ");
     Serial.println(AOGAutoSteerPort);
   }
+
+  // init UPD Port getting DHCP messages
+  if (Eth_udpListenDHCP.begin(DHCP_SERVER_PORT))
+  {
+    Serial.print("Ethernet DHCP UDP listening to port: ");
+    Serial.println(DHCP_SERVER_PORT);
+  }
+
+  // init UPD Port sending DHCP messages
+  if (Eth_udpTransmitDHCP.begin(DHCP_CLIENT_PORT))
+  {
+    Serial.print("Ethernet DHCP UDP sending from port: ");
+    Serial.println(DHCP_CLIENT_PORT);
+  }
 }


### PR DESCRIPTION
Added a UDP server to the AIO board firmware. This allows computer’s IP address, gateway, subnet mask, etc to be set automatically. 

The DHCP server uses UDP as its transport layer and listens on port 67. The MIT licensed DHCP server implementation is from https://github.com/pkulchenko/DHCPLite. 

Leaving this pull request as a draft until all feedback has been addressed. Discussion on this topic can be found here https://discourse.agopengps.com/t/simple-ethernet-setup-for-the-aio-board-using-dhcp/19410/3. 